### PR TITLE
feat: Migrate to UI5 1.142.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/SAP-samples/ui5-typescript-helloworld.git"
   },
   "devDependencies": {
-    "@types/openui5": "1.131.0",
+    "@types/openui5": "1.142.0",
     "@ui5/cli": "^4",
     "@ui5/linter": "^1.5.0",
     "babel-plugin-istanbul": "^7.0.0",

--- a/step-by-step.md
+++ b/step-by-step.md
@@ -256,7 +256,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.142.0"
   libraries:
     - name: sap.m
     - name: sap.ui.core
@@ -455,7 +455,7 @@ resources:
       webapp: dist
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.142.0"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/ui5-coverage.yaml
+++ b/ui5-coverage.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.132.1"
+  version: "1.142.0"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/ui5-dist.yaml
+++ b/ui5-dist.yaml
@@ -8,7 +8,7 @@ resources:
       webapp: dist
 framework:
   name: OpenUI5
-  version: "1.132.1"
+  version: "1.142.0"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/ui5.yaml
+++ b/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.142.0"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/webapp/test/testsuite.qunit.ts
+++ b/webapp/test/testsuite.qunit.ts
@@ -1,3 +1,5 @@
+import type {SuiteConfiguration} from "sap/ui/test/starter/config"; // Available since UI5 1.142
+
 export default {
 	name: "Testsuite for the TypesScript Hello World app",
 	defaults: {
@@ -27,4 +29,4 @@ export default {
 			title: "Integration tests for the TypeScript Hello World app"
 		},
 	}
-};
+} satisfies SuiteConfiguration;


### PR DESCRIPTION
- Use the latest UI5 framework version 1.142.0
- Use the new TS types for the test starter configuration

JIRA: CPOUI5FOUNDATION-1123
